### PR TITLE
fix: 404 documentation urls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM nginxinc/nginx-unprivileged:1.25.4
 LABEL org.opencontainers.image.source="https://github.com/settlemint/btp-docs"
 
-WORKDIR /usr/share/nginx/html
+WORKDIR /usr/share/nginx/html/documentation
 COPY --chmod=0777 ./build/ /usr/share/nginx/html
 COPY --chmod=0777 ./nginx.conf /etc/nginx/nginx.conf
 COPY --chmod=0777 ./nginx.default.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
HTML files are currently located at` /html/docs `:

![image](https://github.com/settlemint/btp-docs/assets/1754718/1906627b-839a-4cad-b691-932d92427ef4)

but are requested as: 

`"GET /documentation/docs/using-platform/add-a-node-to-a-network/ HTTP/1.1", host: "patrick.settlemint.be"`



resulting in Error:

`[error] 29#29: *82 "/usr/share/nginx/html/documentation/docs/using-platform/add-a-node-to-a-network/index.html" is not found (2: No such file or directory)`
