### PR TITLE
fix: adjsut observability docs according latest change

### DIFF
--- a/docs/launch-platform/self-hosted/installing-on-an-existing-cluster/introduction.md
+++ b/docs/launch-platform/self-hosted/installing-on-an-existing-cluster/introduction.md
@@ -28,7 +28,7 @@ It also provides numerous benefits, such as enabling you to specify the high ava
 
 After finishing the installation, you will have access to a suite of services and tools designed to support you throughout your blockchain journey. To explore these tools in detail, we invite you to visit our [Developer Hub](/docs/about-settlemint/intro/).
 
-- **Public chains**: Polygon PoS, Polygon zkevm, Ethereum, Avalanche, Arbitrum, Optimism, Binance Smart Chain *(Internet access required)*
+- **Public chains**: Polygon PoS, Polygon zkevm, Ethereum, Avalanche, Arbitrum, Optimism, Binance Smart Chain, Fantom, Hedera *(Internet access required)*
 - **Private chains**: Hyperledger Besu, Quorum, Hyperledger Fabric
 - **Block Explorers**: Otterscan for Public networks, Blockscout for permissioned
 - **Storage**: IPFS, MinIO

--- a/docs/launch-platform/self-hosted/installing-on-an-existing-cluster/prerequisites/Infrastructure.md
+++ b/docs/launch-platform/self-hosted/installing-on-an-existing-cluster/prerequisites/Infrastructure.md
@@ -195,16 +195,13 @@ vault:
   secretId: "<secret id>"
 ```
 
-## Prometheus / Loki
+## Observability
 
-The observability suite within the BTP leverages Prometheus and Loki for monitoring and logging. You are required to specify the API endpoints for these services. It’s worth noting that Prometheus can be replaced with API-compatible alternatives, such as VictoriaMetrics, if preferred.
+The observability suite within the BTP leverages VictoriaMetrics for metrics, Grafana Loki for logging, Grafana tempo for traces, Grafana for dashboards.
 
 This observability suite is optional and can be activated as described below.
 
 ### A typical set of parameters you should collect:
-
-- Prometheus API URL: this is an example from Grafana cloud: `https://prometheus-prod-01-eu-west-0.grafana.net/api/prom/api/v1/`
-- Loki API URL: this is an example from Grafana cloud: `https://logs-prod-eu-west-0.grafana.net/loki/api/v1/`
 
  [In your values file](/docs/launch-platform/self-hosted/installing-on-an-existing-cluster/run-the-Installation/)
 
@@ -212,12 +209,75 @@ This observability suite is optional and can be activated as described below.
 ```yaml
 features:
   observability:
+    enabled: true
     metrics:
       enabled: true
-      apiUrl: "https://prometheus-prod-01-eu-west-0.grafana.net/api/prom/api/v1/"
     logs:
       enabled: true
-      apiUrl: "http://loki-gateway.observability.svc.cluster.local/loki/api/v1/"
+    traces:
+      enabled: true
+      collector: "http://tempo:4318/v1/traces". # internal k8s address of tempo service
+observability:
+  metrics-server:
+    # -- Most cloud providers have a metrics server already installed, so we don't need to install it. EKS does not
+    enabled: false
+  kube-state-metrics:
+    enabled: true
+  victoria-metrics-single:
+    enabled: true
+    basicAuth: "somepassword" # password in htpasswd format, use htpasswd utility to geenrate it
+      ingress:
+        enabled: true
+        annotations:
+          kubernetes.io/ingress.class: settlemint-nginx
+        hosts:
+          - name: "metrics.console.settlemint.local"
+            path: /
+            port: http
+        ingressClassName: settlemint-nginx
+  loki:
+    enabled: true
+    basicAuth: "somepassword" # password in htpasswd format, use htpasswd utility to geenrate it
+    gateway:
+      ingress:
+        enabled: true
+        ingressClassName: settlemint-nginx
+        hosts:
+          - host: "logs.console.settlemint.local"
+            paths:
+              - path: /
+                pathType: Prefix
+    singleBinary:
+    persistence:
+      size: 100Gi
+  alloy:
+    enabled: true
+    endpoints:
+      external:
+        prometheus:
+          enabled: false
+          url: ""
+        loki:
+          enabled: false
+          url: ""
+        otel:
+          enabled: false
+          url: ""
+  grafana:
+    enabled: true
+    auth:
+      username: username
+      password: password
+    ingress:
+      enabled: true
+      ingressClassName: settlemint-nginx
+      hosts:
+        - grafana.console.settlemint.local
+    grafana.ini:
+      server:
+        root_url: https://grafana.console.settlemint.local
+  tempo:
+    enabled: true
 ```
 
 ## Kubernetes Target Clusters

--- a/docs/launch-platform/self-hosted/monitoring.md
+++ b/docs/launch-platform/self-hosted/monitoring.md
@@ -1,4 +1,0 @@
-# Monitoring
-
-If you have chosen the embedded Prometheus option, you can configure metrics on the
-Application dashboard using `http://prometheus:9090`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Expanded the list of supported public blockchain networks to include "Fantom" and "Hedera."
	- Enhanced the observability section, now covering multiple tools including VictoriaMetrics and Grafana Tempo, with updated configuration options for a more robust setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->