### PR TITLE
fix: main button dark mode background

### DIFF
--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -40,6 +40,10 @@
   justify-content: center;
 }
 
+[data-theme='dark'] .mainButton {
+  background-color: #346eee;
+}
+
 .mainButton {
   background-color: #ffffff;
   color: #346eee;


### PR DESCRIPTION
Request a demo button is ok again: 
![CleanShot 2025-01-08 at 15 22 45@2x](https://github.com/user-attachments/assets/c04a923b-aa6e-426e-8313-bdf80a24feae)

## Summary by Sourcery

Bug Fixes:
- Set the correct background color for the main button when dark mode is enabled.