### PR TITLE
fix: remove sec headers

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -49,21 +49,5 @@ http {
 
     #gzip  on;
 
-    # Add security headers
-    add_header Content-Security-Policy "default-src 'self';
-        script-src 'self' https://www.google-analytics.com;
-        style-src 'self' https://fonts.googleapis.com;
-        img-src 'self' data: https:;
-        font-src 'self' https://fonts.gstatic.com;
-        connect-src 'self' https://*.settlemint.com;
-        frame-src 'self' https://www.youtube.com https://youtube.com;
-        frame-ancestors 'none';
-        object-src 'none';
-        base-uri 'self';
-        form-action 'self'" always;
-    add_header X-Frame-Options "DENY" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Removed security headers from the Nginx configuration.