### PR TITLE
fix: redirect loop

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,7 @@ const config = {
   reactStrictMode: true,
   output: 'standalone',
   basePath: '/documentation',
+  trailingSlash: true,
   serverExternalPackages: ['oxc-transform'],
   eslint: {
     ignoreDuringBuilds: true,
@@ -21,6 +22,14 @@ const config = {
   experimental: {
     inlineCss: true,
     reactCompiler: true,
+  },
+  async rewrites() {
+    return [
+      {
+        source: '/documentation',
+        destination: '/documentation/',
+      },
+    ];
   },
 };
 


### PR DESCRIPTION
## Summary by Sourcery

Fixes a redirect loop on the /documentation path by ensuring a trailing slash is present.

Bug Fixes:
- Fixes a redirect loop by adding a trailing slash to the `basePath` and introducing a rewrite rule to redirect `/documentation` to `/documentation/`.

Build:
- Enables `trailingSlash` in the next.config.js file.