### PR TITLE
fix: use redirects instead of rewrites

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -22,12 +22,12 @@ const config = {
     inlineCss: true,
     reactCompiler: true,
   },
-  async rewrites() {
+  async redirects() {
     return [
       {
         source: '/documentation',
         destination: '/documentation/',
-        basePath: false
+        permanent: true,
       }
     ];
   },


### PR DESCRIPTION
## Summary by Sourcery

Migrate from using rewrites to redirects for the /documentation route, and set the redirect to be permanent.