### PR TITLE
fix: blockchain urls

### DIFF
--- a/content/docs/about-settlemint/intro.mdx
+++ b/content/docs/about-settlemint/intro.mdx
@@ -12,28 +12,28 @@ SettleMint makes it easy for any developer to build, deploy and integrate blockc
 <Cards>
   <Card
     title="SettleMint Components"
-    href="/documentation/docs/about-settlemint/components/"
+    href="/docs/about-settlemint/components/"
   >
     Learn about the services and tools you can use on SettleMint
   </Card>
 
   <Card
     title="Supported Blockchains"
-    href="/documentation/docs/about-settlemint/supported-blockchains/"
+    href="/docs/about-settlemint/supported-blockchains/"
   >
     Learn about the supported blockchains that you can use
   </Card>
 
   <Card
     title="Create an Application"
-    href="/documentation/docs/using-platform/create-an-application/"
+    href="/docs/using-platform/create-an-application/"
   >
     Create Your First Application using SettleMint on a Managed Cloud
   </Card>
 
   <Card
     title="Install On-Premise"
-    href="/documentation/docs/launch-platform/self-hosted/installing-on-an-existing-cluster/introduction/"
+    href="/docs/launch-platform/self-hosted/installing-on-an-existing-cluster/introduction/"
   >
     Learn about the supported blockchains that you can use
   </Card>
@@ -46,21 +46,21 @@ Follow these developer guides to start building on SettleMint
 <Cards>
   <Card
     title="Hello World Application"
-    href="/documentation/docs/using-platform/create-an-application/"
+    href="/docs/using-platform/create-an-application/"
   >
     Create Your First Application using SettleMint on a Managed Cloud
   </Card>
 
   <Card
     title="Connect Frontend - NextJS"
-    href="/documentation/docs/developer-guides/connect-frontend/"
+    href="/docs/developer-guides/connect-frontend/"
   >
     Learn how to create a custom frontend by building an ERC20 token transfer application
   </Card>
 
   <Card
     title="Asset Tokenization"
-    href="/documentation/docs/developer-guides/asset-tokenization/"
+    href="/docs/developer-guides/asset-tokenization/"
   >
     Build a Asset Tokenization blockchain application
   </Card>

--- a/content/docs/about-settlemint/supported-blockchains.mdx
+++ b/content/docs/about-settlemint/supported-blockchains.mdx
@@ -14,11 +14,11 @@ SettleMint currently supports the following protocols:
 
 <Cards>
   <Card
-    href="/documentation/docs/blockchain-guides/Hyperledger-Besu/enterprise-ethereum-the-basics/"
+    href="/docs/blockchain-guides/Hyperledger-Besu/enterprise-ethereum-the-basics/"
   >
     <h3 className="mb-4">Hyperledger Besu</h3>
     <div className="flex flex-col items-center gap-4">
-      <div style={{width: '64px', height: '64px', display: 'flex', alignItems: 'center', justifyContent: 'center'}}> 
+      <div style={{width: '64px', height: '64px', display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
         ![Hyperledger Besu](../../img/about-settlemint/blockchain-logos/besu-logo.png)
       </div>
       <div className="text-center">Ethereum client designed to be enterprise-friendly</div>
@@ -26,11 +26,11 @@ SettleMint currently supports the following protocols:
   </Card>
 
   <Card
-    href="/documentation/docs/blockchain-guides/Hyperledger-Fabric/hyperledger-fabric-the-basics/"
+    href="/docs/blockchain-guides/Hyperledger-Fabric/hyperledger-fabric-the-basics/"
   >
     <h3 className="mb-4">Hyperledger Fabric</h3>
     <div className="flex flex-col items-center gap-4">
-      <div style={{width: '64px', height: '64px', display: 'flex', alignItems: 'center', justifyContent: 'center'}}> 
+      <div style={{width: '64px', height: '64px', display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
         ![Hyperledger Fabric](../../img/about-settlemint/blockchain-logos/fabric-logo.png)
       </div>
       <div className="text-center">An enterprise-grade permissioned distributed ledger</div>
@@ -38,11 +38,11 @@ SettleMint currently supports the following protocols:
   </Card>
 
   <Card
-    href="/documentation/docs/blockchain-guides/quorum/quorum-the-basics/"
+    href="/docs/blockchain-guides/quorum/quorum-the-basics/"
   >
     <h3 className="mb-4">Quorum</h3>
     <div className="flex flex-col items-center gap-4">
-      <div style={{width: '74px', height: '64px', display: 'flex', alignItems: 'center', justifyContent: 'center'}}> 
+      <div style={{width: '74px', height: '64px', display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
         ![Quorum](../../img/about-settlemint/blockchain-logos/quorum-logo.png)
       </div>
       <div className="text-center">An implementation of Ethereum supporting data privacy</div>
@@ -54,11 +54,11 @@ SettleMint currently supports the following protocols:
 
 <Cards>
   <Card
-    href="/documentation/docs/blockchain-guides/ethereum/ethereum-the-basics/"
+    href="/docs/blockchain-guides/ethereum/ethereum-the-basics/"
   >
     <h3 className="mb-4">Ethereum</h3>
     <div className="flex flex-col items-center gap-8">
-      <div style={{width: '48px', height: '48px', display: 'flex', alignItems: 'center', justifyContent: 'center'}}> 
+      <div style={{width: '48px', height: '48px', display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
         ![Ethereum](../../img/about-settlemint/blockchain-logos/eth-logo.png)
       </div>
       <div className="text-center">Goerli, Mainnet, Sepolia Testnet & Holesky Testnet. Full nodes</div>
@@ -66,11 +66,11 @@ SettleMint currently supports the following protocols:
   </Card>
 
   <Card
-    href="/documentation/docs/blockchain-guides/avalanche/avalanche-the-basics/"
+    href="/docs/blockchain-guides/avalanche/avalanche-the-basics/"
   >
     <h3 className="mb-4">Avalanche</h3>
     <div className="flex flex-col items-center gap-4">
-      <div style={{width: '64px', height: '64px', display: 'flex', alignItems: 'center', justifyContent: 'center'}}> 
+      <div style={{width: '64px', height: '64px', display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
         ![Avalanche](../../img/about-settlemint/blockchain-logos/avalanche-logo.png)
       </div>
       <div className="text-center">Mainnet & Fuji testnet. Full nodes</div>
@@ -78,11 +78,11 @@ SettleMint currently supports the following protocols:
   </Card>
 
   <Card
-    href="/documentation/docs/blockchain-guides/polygon/polygon-the-basics/"
+    href="/docs/blockchain-guides/polygon/polygon-the-basics/"
   >
     <h3 className="mb-4">Polygon</h3>
     <div className="flex flex-col items-center gap-4">
-      <div style={{width: '64px', height: '64px', display: 'flex', alignItems: 'center', justifyContent: 'center'}}> 
+      <div style={{width: '64px', height: '64px', display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
         ![Polygon](../../img/about-settlemint/blockchain-logos/polygon-logo.webp)
       </div>
       <div className="text-center">Mainnet & Mumbai Testnet. Full node</div>
@@ -90,11 +90,11 @@ SettleMint currently supports the following protocols:
   </Card>
 
   <Card
-    href="/documentation/docs/blockchain-guides/polygon-zkevm/polygon-zkevm-the-basics/"
+    href="/docs/blockchain-guides/polygon-zkevm/polygon-zkevm-the-basics/"
   >
     <h3 className="mb-4">Polygon zkEVM</h3>
     <div className="flex flex-col items-center gap-4">
-      <div style={{width: '64px', height: '64px', display: 'flex', alignItems: 'center', justifyContent: 'center'}}> 
+      <div style={{width: '64px', height: '64px', display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
         ![Polygon zkEVM](../../img/about-settlemint/blockchain-logos/zkevm-logo.png)
       </div>
       <div className="text-center">Mainnet & Testnet. Full nodes</div>
@@ -102,11 +102,11 @@ SettleMint currently supports the following protocols:
   </Card>
 
   <Card
-    href="/documentation/docs/blockchain-guides/Arbitrum/arbitrum-the-basics/"
+    href="/docs/blockchain-guides/Arbitrum/arbitrum-the-basics/"
   >
     <h3 className="mb-4">Arbitrum</h3>
     <div className="flex flex-col items-center gap-4">
-      <div style={{width: '64px', height: '64px', display: 'flex', alignItems: 'center', justifyContent: 'center'}}> 
+      <div style={{width: '64px', height: '64px', display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
         ![Arbitrum](../../img/about-settlemint/blockchain-logos/arbitrum-logo.png)
       </div>
       <div className="text-center">Mainnet & Testnet. Full nodes</div>
@@ -114,11 +114,11 @@ SettleMint currently supports the following protocols:
   </Card>
 
   <Card
-    href="/documentation/docs/blockchain-guides/Optimism/optimism-the-basics/"
+    href="/docs/blockchain-guides/Optimism/optimism-the-basics/"
   >
     <h3 className="mb-4">Optimism</h3>
     <div className="flex flex-col items-center gap-4">
-      <div style={{width: '64px', height: '64px', display: 'flex', alignItems: 'center', justifyContent: 'center'}}> 
+      <div style={{width: '64px', height: '64px', display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
         ![Optimism](../../img/about-settlemint/blockchain-logos/optimism-logo.png)
       </div>
       <div className="text-center">OP Mainnet & OP Goerli. Full nodes</div>
@@ -126,11 +126,11 @@ SettleMint currently supports the following protocols:
   </Card>
 
   <Card
-    href="/documentation/docs/blockchain-guides/Hedera/hedera-the-basics/"
+    href="/docs/blockchain-guides/Hedera/hedera-the-basics/"
   >
     <h3 className="mb-4">Hedera</h3>
     <div className="flex flex-col items-center gap-4">
-      <div style={{width: '64px', height: '64px', display: 'flex', alignItems: 'center', justifyContent: 'center'}}> 
+      <div style={{width: '64px', height: '64px', display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
         ![Hedera](../../img/about-settlemint/blockchain-logos/hedera-logo.png)
       </div>
       <div className="text-center">Hedera Mainnet & Testnet. Full nodes</div>

--- a/content/docs/developer-guides/user-wallets-and-scp.md
+++ b/content/docs/developer-guides/user-wallets-and-scp.md
@@ -4,9 +4,9 @@ description: Guide for creating user wallets and sending transactions using the 
 ---
 
 
-In this document, we will guide you through the creation of user wallets using the smart contract portal on the SettleMint platform. We will also show how you can send transactions to your contracts and sign them with one of the wallets in the portal. 
+In this document, we will guide you through the creation of user wallets using the smart contract portal on the SettleMint platform. We will also show how you can send transactions to your contracts and sign them with one of the wallets in the portal.
 
-## Required platform deployments: 
+## Required platform deployments:
 - Blockchain network (e.g. besu)
 - An HD ECDSA private key
 - An empty smart contract set
@@ -17,8 +17,8 @@ For the purpose of this guide, you can set up a Besu network with one validator 
 
 ### HD ECDSA
 Create the user wallet deployment along with one user wallet. For detailed instructions, see:
-- [User Wallet Guide](https://console.settlemint.com/documentation/docs/using-platform/user_wallet/)
-- [Private Keys Guide](https://console.settlemint.com/documentation/docs/using-platform/private-keys/)
+- [User Wallet Guide](https://console.settlemint.com/docs/using-platform/user_wallet/)
+- [Private Keys Guide](https://console.settlemint.com/docs/using-platform/private-keys/)
 
 Make sure to enable the address on your node.
 
@@ -35,7 +35,7 @@ Keep the address of the smart contract, you will need it to send a transaction i
 You will also need the contract ABI. You can find it in **out/counter.sol/counter.json**
 
 ### Smart contract portal
-Deploy the portal on your blockchain network and use the contract that you copied from the IDE. This will create a custom API automatically. 
+Deploy the portal on your blockchain network and use the contract that you copied from the IDE. This will create a custom API automatically.
 
 ![Smart contract portal](../../img/user-wallet-scp-images/image8.png)
 
@@ -44,19 +44,19 @@ To create a new wallet go to the REST tab of your portal and enter full screen m
 
 ![REST tab](../../img/user-wallet-scp-images/image7.png)
 
-Next, expand the Wallet section on the left and select `/wallets`. 
+Next, expand the Wallet section on the left and select `/wallets`.
 
 ![Wallet section](../../img/user-wallet-scp-images/image1.png)
 
-You can test the request directly from the portal by clicking on **Test Request**. This opens a form in which you can enter the **keyVaultId** of your wallet and the user name of your choice: 
+You can test the request directly from the portal by clicking on **Test Request**. This opens a form in which you can enter the **keyVaultId** of your wallet and the user name of your choice:
 
 ![Test request form](../../img/user-wallet-scp-images/image2.png)
 
-After you've sent the request, you can check your HD ECDSA wallet in the private key section. You should see a new account in the account section: 
+After you've sent the request, you can check your HD ECDSA wallet in the private key section. You should see a new account in the account section:
 
 ![Account section](../../img/user-wallet-scp-images/image6.png)
 
-Alternatively, you can also send the request using cURL: 
+Alternatively, you can also send the request using cURL:
 
 ```bash
 curl https://scs-portal-url/wallets \

--- a/content/docs/developer-guides/user-wallets-and-scp.md
+++ b/content/docs/developer-guides/user-wallets-and-scp.md
@@ -17,8 +17,8 @@ For the purpose of this guide, you can set up a Besu network with one validator 
 
 ### HD ECDSA
 Create the user wallet deployment along with one user wallet. For detailed instructions, see:
-- [User Wallet Guide](https://console.settlemint.com/docs/using-platform/user_wallet/)
-- [Private Keys Guide](https://console.settlemint.com/docs/using-platform/private-keys/)
+- [User Wallet Guide](https://console.settlemint.com/documentation/docs/using-platform/user_wallet/)
+- [Private Keys Guide](https://console.settlemint.com/documentation/docs/using-platform/private-keys/)
 
 Make sure to enable the address on your node.
 

--- a/content/docs/developer-guides/utilizing-ai-features.mdx
+++ b/content/docs/developer-guides/utilizing-ai-features.mdx
@@ -168,7 +168,7 @@ Now that you have built an AI-powered workflow, here are some blockchain-specifi
 
 For further resources, check out:
 
-- [SettleMint Integration Studio Documentation](https://console.settlemint.com/docs/using-platform/integration-studio/)
+- [SettleMint Integration Studio Documentation](https://console.settlemint.com/documentation/docs/using-platform/integration-studio/)
 - [Node-RED Documentation](https://nodered.org/docs/)
 - [OpenAI API Documentation](https://beta.openai.com/docs/)
 - [Hasura pgvector Documentation](https://hasura.io/docs/3.0/connectors/postgresql/native-operations/vector-search/)

--- a/content/docs/developer-guides/utilizing-ai-features.mdx
+++ b/content/docs/developer-guides/utilizing-ai-features.mdx
@@ -168,7 +168,7 @@ Now that you have built an AI-powered workflow, here are some blockchain-specifi
 
 For further resources, check out:
 
-- [SettleMint Integration Studio Documentation](https://console.settlemint.com/documentation/docs/using-platform/integration-studio/)
+- [SettleMint Integration Studio Documentation](https://console.settlemint.com/docs/using-platform/integration-studio/)
 - [Node-RED Documentation](https://nodered.org/docs/)
 - [OpenAI API Documentation](https://beta.openai.com/docs/)
 - [Hasura pgvector Documentation](https://hasura.io/docs/3.0/connectors/postgresql/native-operations/vector-search/)

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -11,22 +11,22 @@ SettleMint makes it easy for any developer to build, deploy and integrate blockc
   <Card
     title="SettleMint Components"
     description="Learn about the services and tools you can can use on SettleMint"
-    href="/documentation/docs/about-settlemint/components/"
+    href="/docs/about-settlemint/components/"
   />
   <Card
     title="Supported Blockchains"
     description="Learn about the supported blockchains that you can use"
-    href="/documentation/docs/about-settlemint/supported-blockchains/"
+    href="/docs/about-settlemint/supported-blockchains/"
   />
   <Card
     title="Create an Application"
     description="Create Your First Application using SettleMint on a Managed Cloud"
-    href="/documentation/docs/using-platform/create-an-application/"
+    href="/docs/using-platform/create-an-application/"
   />
   <Card
     title="Install On-Premise"
     description="Learn about the supported blockchains that you can use"
-    href="/documentation/docs/launch-platform/self-hosted/installing-on-an-existing-cluster/introduction/"
+    href="/docs/launch-platform/self-hosted/installing-on-an-existing-cluster/introduction/"
   />
 </Cards>
 
@@ -38,16 +38,16 @@ Follow these developer guides to start building on SettleMint
   <Card
     title="Hello World Application"
     description="Create Your First Application using SettleMint on a Managed Cloud"
-    href="/documentation/docs/using-platform/create-an-application/"
+    href="/docs/using-platform/create-an-application/"
   />
   <Card
     title="Connect Frontend - NextJS"
     description="Learn how to create a custom frontend by building and ERC20 token transfer application"
-    href="/documentation/docs/developer-guides/connect-frontend/"
+    href="/docs/developer-guides/connect-frontend/"
   />
   <Card
     title="Asset Tokenization"
     description="Build a Asset Tokenization blockchain application"
-    href="/documentation/docs/developer-guides/asset-tokenization/"
+    href="/docs/developer-guides/asset-tokenization/"
   />
 </Cards>


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Fixes broken links in documentation by removing the `/documentation` prefix from URLs.