### PR TITLE
fix: rename the googleSecretManager to gcpSecretManager

### DIFF
--- a/content/docs/launching-the-platform/self-hosted-onprem/prerequisites/secret-management.mdx
+++ b/content/docs/launching-the-platform/self-hosted-onprem/prerequisites/secret-management.mdx
@@ -14,7 +14,7 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
   <Card>
     ### Platform Options
     - HashiCorp Vault
-    - Google Secret Manager
+    - GCP Secret Manager
     - AWS Secret Manager
   </Card>
 
@@ -29,9 +29,9 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
 ## Deployment Options
 
-<Tabs items={['Google Secret Manager', 'HCP Vault', 'Self-Hosted Vault', 'AWS Secret Manager']}>
-  <Tab value="Google Secret Manager">
-    ### Google Secret Manager Setup
+<Tabs items={['GCP Secret Manager', 'HCP Vault', 'Self-Hosted Vault', 'AWS Secret Manager']}>
+  <Tab value="GCP Secret Manager">
+    ### GCP Secret Manager Setup
 
     <Steps>
       ### Enable the Secret Manager API
@@ -51,7 +51,7 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
     </Steps>
 
     <Callout type="info">
-      **Google Secret Manager provides:**
+      **GCP Secret Manager provides:**
       - Fully managed service
       - Automatic replication
       - Fine-grained IAM controls
@@ -62,7 +62,7 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
       **Helm Chart Values:**
       ```yaml
       # values.yaml for Helm installation
-      googleSecretManager:
+      gcpSecretManager:
         # -- Enable Google Secret Manager integration
         enabled: true
         # -- The Google Cloud project ID
@@ -249,7 +249,7 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
 Choose one of the following configurations for your Helm values:
 
-**For Google Secret Manager:**
+**For GCP Secret Manager:**
 
 - [ ] GCP Project ID
 - [ ] Service Account JSON key
@@ -260,7 +260,7 @@ vault:
   enabled: false
 awsSecretManager:
   enabled: false
-googleSecretManager:
+gcpSecretManager:
   enabled: true
   projectId: "your-project-id"
   credentials: |
@@ -278,7 +278,7 @@ googleSecretManager:
 
 ```yaml
 # values.yaml
-googleSecretManager:
+gcpSecretManager:
   enabled: false
 awsSecretManager:
   enabled: false
@@ -300,7 +300,7 @@ vault:
 # values.yaml
 vault:
   enabled: false
-googleSecretManager:
+gcpSecretManager:
   enabled: false
 awsSecretManager:
   enabled: true
@@ -319,8 +319,8 @@ Make sure to:
 
 ## Validation
 
-<Tabs items={['Google Secret Manager', 'HashiCorp Vault', 'AWS Secret Manager']}>
-  <Tab value="Google Secret Manager">
+<Tabs items={['GCP Secret Manager', 'HashiCorp Vault', 'AWS Secret Manager']}>
+  <Tab value="GCP Secret Manager">
     ```bash
     # Set environment variables
     export GOOGLE_APPLICATION_CREDENTIALS="path/to/service-account.json"
@@ -365,7 +365,7 @@ Make sure to:
 
 <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
   <Card>
-    ### Google Secret Manager Issues
+    ### GCP Secret Manager Issues
     - Verify service account permissions
     - Check credentials file format
     - Confirm API is enabled


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Update documentation to consistently use 'GCP Secret Manager' terminology across all sections, including headings, tab labels, and configuration examples