### PR TITLE
fix: update-atk-intro-link

### DIFF
--- a/content/docs/about-settlemint/introduction.mdx
+++ b/content/docs/about-settlemint/introduction.mdx
@@ -26,10 +26,7 @@ Self-Managed (on-premises) model, SettleMint's integrated approach ensures
 robust security, seamless scalability, and simplified operational management for
 enterprise-grade decentralized applications.
 
-<div style={{ display: 'flex', justifyContent: 'center', marginBottom: '2rem', width: '70%', margin: '0 auto' }}>
-  ![SettleMint Platform Model](../../img/about-settlemint/platformModel.png)
-</div>
-
+![SettleMint Platform](../../img/platform.png)
 
 ---
 
@@ -67,7 +64,7 @@ off-chain integrations, and more).
 |                                           | **Custom Deployments**           | Containerize and deploy both front-end and back-end components. This approach makes it straightforward to scale each component independently and roll out updates efficiently.                                                                                                            | [Custom Deployments](/platform-components/custom-deployments/custom-deployment)                      |
 | **5. Security & Authentication**          | **Private Key Management**       | Various options, from software-based storage to Hardware Security Modules (HSMs), for safeguarding cryptographic keys and ensuring secure transactions.                                                                                                                                   | [Key Management](/platform-components/security-and-authentication/private-keys)                      |
 |                                           | **Access Tokens (PAT/AAT)**      | Control access to the platform and its APIs using token-based authentication. Enables role-based permissions for both user and machine (app) identities.                                                                                                                                  | [Access Tokens](/platform-components/security-and-authentication/personal-access-tokens)             |
-| **7. Application Kits**                   | **Asset Tokenization Kit**       | A full-stack accelerator for tokenizing assets, including prebuilt smart contracts and a ready-to-use dApp codebase to jump-start tokenization projects.                                                                                                                                  | [Asset Tokenization Kit](/application-kits/asset-tokenization/asset-tokenization-kit)                |
+| **7. Application Kits**                   | **Asset Tokenization Kit**       | A full-stack accelerator for tokenizing assets, including prebuilt smart contracts and a ready-to-use dApp codebase to jump-start tokenization projects.                                                                                                                                  | [Asset Tokenization Kit](/application-kits/introduction)                |
 
 ---
 


### PR DESCRIPTION
## Summary by Sourcery

Update documentation links and image in the SettleMint introduction page

Documentation:
- Replace the platform model image with a new image reference
- Update the Asset Tokenization Kit link to point to the introduction page instead of the specific kit page