### PR TITLE
fix: fix-atk-github-image

### DIFF
--- a/content/docs/application-kits/asset-tokenization/introduction.mdx
+++ b/content/docs/application-kits/asset-tokenization/introduction.mdx
@@ -500,7 +500,7 @@ To begin using the kit:
 4. **Review documentation and API references** to begin customizing the
    application
 
-![Asset Tokenization Kit Code](../../../img/application-kits/atk-code.png)
+![Asset Tokenization Kit Code](../../../img/application-kits/atk-github.png)
 
 Comprehensive guides, code samples, and pre-configured environments are
 available to reduce onboarding time for development teams.


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Replace the image source for the Asset Tokenization Kit code screenshot from 'atk-code.png' to 'atk-github.png'