### PR TITLE
docs: add HA capabilities to The Graph documentation

### DIFF
--- a/content/docs/building-with-settlemint/evm-chains-guide/setup-graph-middleware.mdx
+++ b/content/docs/building-with-settlemint/evm-chains-guide/setup-graph-middleware.mdx
@@ -76,11 +76,32 @@ providing essential services like data indexing, API access, and event
 monitoring. Before adding middleware, ensure you have an application and
 blockchain node in place.
 
+For production environments requiring high availability, SettleMint offers **HA Graph** 
+configurations that provide redundancy and automatic failover. HA Graph deployments 
+include multiple indexing nodes and **HA Graph Postgres** for database redundancy, 
+ensuring your subgraph queries remain available even during maintenance or unexpected 
+outages.
+
 ### How to add middleware
 
 ![Add Graph Middleware](../../../img/building-with-settlemint/add-graph-middleware.png)
 
 <include>../../../snippets/create-middleware.mdx</include>
+
+#### Choosing between standard and HA deployment
+
+When adding Graph middleware, consider these factors:
+
+**Standard Graph deployment** is suitable for:
+- Development and testing environments
+- Applications with flexible uptime requirements
+- Cost-conscious deployments
+
+**HA Graph deployment** is recommended for:
+- Production applications requiring 99.9%+ uptime
+- Mission-critical indexing services
+- Applications with zero-tolerance for query downtime
+- Enterprise deployments with SLA requirements
 
 ### Manage middleware
 

--- a/content/docs/knowledge-bank/subgraphs.mdx
+++ b/content/docs/knowledge-bank/subgraphs.mdx
@@ -38,6 +38,11 @@ Subgraph developers define the indexing logic and deploy it to the network. Once
 deployed, their subgraphs become accessible via GraphQL endpoints and are
 maintained by indexers without requiring centralized APIs.
 
+In enterprise deployments, SettleMint provides **HA Graph** configurations that ensure 
+subgraph availability through redundant indexing nodes and **HA Graph Postgres** for 
+database failover. This architecture is essential for production applications where 
+continuous data access is critical.
+
 The protocol provides deterministic indexing through WASM-based mappings,
 scalability through sharding and modular design, and economic incentives to
 ensure data availability and integrity.

--- a/content/docs/platform-components/middleware-and-api-layer/attestation-indexer.mdx
+++ b/content/docs/platform-components/middleware-and-api-layer/attestation-indexer.mdx
@@ -521,8 +521,9 @@ The SettleMint attestation indexer is a specialized middleware that indexes and 
 - **High-performance GraphQL API** for complex data queries
 - **Scalable architecture** designed for production workloads
 - **Seamless integration** with any EVM-compatible chain
+- **High availability options** for enterprise deployments
 
-SettleMint's implementation provides a complete attestation solution with both the required smart contracts and optimized indexing service, eliminating the complexity of manually setting up and maintaining these components separately.
+SettleMint's implementation provides a complete attestation solution with both the required smart contracts and optimized indexing service, eliminating the complexity of manually setting up and maintaining these components separately. For production environments, the attestation indexer can be deployed in HA configuration with redundant indexing nodes and HA Postgres database backend.
 
 ### How the indexer works
 

--- a/content/docs/platform-components/middleware-and-api-layer/graph-middleware.mdx
+++ b/content/docs/platform-components/middleware-and-api-layer/graph-middleware.mdx
@@ -16,7 +16,7 @@ blockchain node in place.
 <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-8 mb-8">
   <Card>
     ## Available Options
-    - **Graph Middleware** - For EVM chains, providing subgraph-based indexing with GraphQL API
+    - **Graph Middleware** - For EVM chains, providing subgraph-based indexing with GraphQL API (available in HA configuration)
     - **Smart contract portal** - For EVM chains, offering REST & GraphQL APIs with webhooks
     - **FabConnect** - For Hyperledger Fabric, providing RESTful API
     - **Attestation Indexer** - Specialized indexer for attestations with GraphQL API
@@ -28,6 +28,7 @@ blockchain node in place.
     - API access
     - Event monitoring
     - Webhook support
+    - High availability options
   </Card>
 </div>
 
@@ -47,6 +48,7 @@ subgraphs. Use this middleware when you need:
 - Custom indexing logic through subgraph manifests
 - Complex GraphQL queries
 - Real-time data updates
+- High availability for enterprise-grade reliability
 
 ### Using the graph sdk
 
@@ -74,6 +76,11 @@ const { client: graphClient, graphql } = createTheGraphClient({
 blockchain data from networks. It can be used with all EVM-compatible chains
 like Ethereum, Hyperledger Besu, Polygon, Avalanche, etc. You can run it on your
 own blockchain nodes (both public and permissioned).
+
+SettleMint's implementation supports **HA Graph** configurations for enterprise deployments, 
+providing redundancy and failover capabilities to ensure continuous data availability. For 
+production workloads requiring maximum uptime, HA Graph with HA Graph Postgres ensures 
+both the indexing service and its database backend remain highly available.
 
 Using the Graph protocol, you can create **subgraphs** that define which
 blockchain data will be indexed. The middleware will then use these subgraphs to


### PR DESCRIPTION
## Summary
- Added mentions of HA (High Availability) capabilities to existing Graph documentation
- Updated middleware and indexing documentation to highlight enterprise-grade reliability features
- Did not create separate pages - integrated HA information into existing content as requested

## Test plan
- [ ] Review that HA mentions are appropriately integrated into existing pages
- [ ] Verify no new pages were created
- [ ] Ensure documentation clearly explains when to use HA vs standard deployments

## Summary by Sourcery

Integrate High Availability (HA) capabilities into existing Graph documentation by adding references to HA Graph configurations and HA Graph Postgres, and providing guidance on selecting between standard and HA deployments for production reliability.

Documentation:
- Add HA Graph and HA Graph Postgres references to Graph middleware, subgraphs, and attestation indexer documentation to highlight redundancy and failover features
- Include a decision matrix outlining when to use standard vs HA deployments based on uptime requirements
- Emphasize enterprise-grade reliability features like multi-node indexing and database failover in production contexts