### PR TITLE
overlap-fix

### DIFF
--- a/src/app/global.css
+++ b/src/app/global.css
@@ -390,6 +390,23 @@ th {
 
 #nd-toc {
   background-color: var(--sidebar-background);
+  position: fixed !important;
+  right: 0 !important;
+  top: 4rem !important;
+  height: calc(100vh - 4rem) !important;
+  z-index: 50 !important;
+  overflow-y: auto !important;
+  width: auto !important;
+  min-width: 250px !important;
+  max-width: 300px !important;
+  padding-top: 2rem !important;
+}
+
+/* Hide TOC on smaller screens to prevent overlap */
+@media (max-width: 1024px) {
+  #nd-toc {
+    display: none !important;
+  }
 }
 
 #nd-toc > div {


### PR DESCRIPTION
Overlap fix

## Summary by Sourcery

Rework the TOC panel to be fixed on the right with set width/height and scrolling, and disable it on smaller screens to prevent overlap

Enhancements:
- Reposition the table of contents as a fixed sidebar with controlled dimensions and overflow
- Hide the table of contents on viewports narrower than 1024px to avoid content overlap